### PR TITLE
Add makefile for building on AMDGPU systems. Draft docs

### DIFF
--- a/SRC/FEMAIN/Makefile.hip
+++ b/SRC/FEMAIN/Makefile.hip
@@ -122,7 +122,7 @@ TEST_OBJS = ./FastEddy.o \
 # Targets
 # ###############################################################################
 
-all: FastEddy
+all: hipify FastEddy
 
 hipify:
 	find ../ -name "*.cu" -exec hipify-perl -inplace {} \;

--- a/SRC/FEMAIN/Makefile.hip
+++ b/SRC/FEMAIN/Makefile.hip
@@ -1,0 +1,210 @@
+################################################################################
+# FastEddy®: SRC/FEMAIN/Makefile
+# ©2016 University Corporation for Atmospheric Research
+#
+# This file is licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ################################################################################
+#
+# ################################################################################
+# # Available build targets
+# ################################################################################
+
+TARGETS = \
+       FastEddy 
+
+
+################################################################################
+## Compiler and flags
+################################################################################
+
+TEST_CC = mpicc
+TEST_CU_CC = hipcc
+
+DEBUG_CFLAGS = -g 
+
+DEFINES = -DCUB_IGNORE_DEPRECATED_CPP_DIALECT -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT
+
+
+TEST_CFLAGS = -Wall -m64 $(shell ${ROCM_PATH}/bin/hipconfig --cpp_config) ${DEFINES} ${INCLUDES} ${OTHER_INCLUDES}
+ARCH_CU_FLAGS = --offload-arch=gfx90a
+TEST_CU_CFLAGS = ${ARCH_CU_FLAGS} -m64 -std=c++14 ${DEFINES} ${INCLUDES} ${OTHER_INCLUDES}
+
+L_CPPFLAGS =
+
+#OTHER_INCLUDES =
+# For compilation on NCAR's Casper or Derecho supercomputers use the OTHER_INCLUDES below
+#OTHER_INCLUDES = -I${NCAR_ROOT_MPI}/include
+
+TEST_LDFLAGS = -L.
+TEST_CU_LDFLAGS = -L.  -fgpu-rdc
+
+TEST_LIBS = -lm -L${OPENMPI_ROOT}/lib -lmpi -lstdc++ -L${ROCM_PATH}/lib -lamdhip64 -lhiprand -L${NETCDF_C_ROOT}/lib -lnetcdf
+TEST_CU_LIBS = -lmpi -L${ROCM_PATH}/lib -lhiprtc
+
+
+################################################################################
+# Sub-directories to INCLUDE 
+# ################################################################################
+
+INCLUDES = \
+	-I. \
+	-I../TIME_INTEGRATION/ \
+	-I../TIME_INTEGRATION/CUDA \
+	-I../HYDRO_CORE \
+	-I../HYDRO_CORE/CUDA \
+	-I../GRID \
+	-I../GRID/CUDA \
+	-I../FECUDA \
+	-I../IO/ \
+	-I../MEM_UTILS/ \
+	-I../FEMPI/ \
+	-I../PARAMETERS/
+
+################################################################################
+# Headers
+# ###############################################################################
+
+TEST_HDRS = \
+	../TIME_INTEGRATION/time_integration.h \
+        ../TIME_INTEGRATION/CUDA/cuda_timeInt.h \
+        ../TIME_INTEGRATION/CUDA/cuda_timeIntDevice_cu.h \
+	../HYDRO_CORE/hydro_core.h \
+	../HYDRO_CORE/CUDA/cuda_hydroCore.h \
+	../HYDRO_CORE/CUDA/cuda_hydroCoreDevice_cu.h \
+	../GRID/grid.h \
+	../GRID/CUDA/cuda_grid.h \
+	../GRID/CUDA/cuda_gridDevice_cu.h \
+        ../FECUDA/fecuda.h \
+        ../FECUDA/fecuda_Device_cu.h \
+	../IO/io.h \
+	../MEM_UTILS/mem_utils.h \
+	../FEMPI/fempi.h \
+	../PARAMETERS/parameters.h \
+	../PARAMETERS/hashTable.h
+
+################################################################################
+# Objects
+# ###############################################################################
+
+TEST_LIB_OBJS =
+
+TEST_OBJS = ./FastEddy.o \
+	../TIME_INTEGRATION/time_integration.o \
+        ../TIME_INTEGRATION/CUDA/cuda_timeInt.o \
+        ../TIME_INTEGRATION/CUDA/cuda_timeIntDevice.o \
+	../HYDRO_CORE/hydro_core.o \
+	../HYDRO_CORE/CUDA/cuda_hydroCore.o \
+	../HYDRO_CORE/CUDA/cuda_hydroCoreDevice.o \
+	../GRID/grid.o \
+	../GRID/CUDA/cuda_grid.o \
+	../GRID/CUDA/cuda_gridDevice.o \
+        ../FECUDA/fecuda.o \
+        ../FECUDA/fecuda_Device.o \
+	../IO/io.o \
+	../IO/ioVarsList.o \
+	../MEM_UTILS/mem_utils.o \
+	../FEMPI/fempi.o \
+	../PARAMETERS/parameters.o \
+	../PARAMETERS/hashTable.o
+
+################################################################################
+# Targets
+# ###############################################################################
+
+all: FastEddy
+
+hipify:
+	find ../ -name "*.cu" -exec hipify-perl -inplace {} \;
+	find ../ -name "*.h" -exec hipify-perl -inplace {} \;
+	find ../ -name "*.prehip" -exec rm {} \;
+
+
+################################################################################
+# Generic compile rules
+# ################################################################################
+%.o: %.cu
+	rm -rf ./FastEddy_devlink.o; \
+	$(TEST_CU_CC) $(TEST_CU_CFLAGS) -fgpu-rdc -c $< -o $@
+
+.c.o:
+	${COMP_FLAGS} -c $< -o $@
+
+################################################################################
+# Module=specific compile rules
+# ################################################################################
+
+../TIME_INTEGRATION/CUDA/cuda_timeIntDevice.o: ../TIME_INTEGRATION/CUDA/cuda_timeIntDevice.cu \
+        ../TIME_INTEGRATION/CUDA/cuda_RKschemes.cu
+	rm -rf ./FastEddy_devlink.o; \
+	$(TEST_CU_CC) $(TEST_CU_CFLAGS) -fgpu-rdc -c $< -o $@
+
+../IO/io.o: ../IO/io.c \
+	../IO/io_netcdf.c \
+	../IO/io_binary.c 
+	$(COMP_FLAGS) -c $< -o $@
+
+../FECUDA/fecuda_Device.o: ../FECUDA/fecuda_Device.cu \
+	../FECUDA/fecuda_Utils.cu \
+	../FECUDA/fecuda_PlugIns.cu 
+	rm -rf ./FastEddy_devlink.o; \
+	$(TEST_CU_CC) $(TEST_CU_CFLAGS) -fgpu-rdc -c $< -o $@
+
+../HYDRO_CORE/CUDA/cuda_hydroCoreDevice.o: ../HYDRO_CORE/CUDA/cuda_hydroCoreDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_BaseStateDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_buoyancyDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_coriolisDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_pressureDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_BCsDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_rayleighDampingDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_advectionDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_molecularDiffDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_surfaceLayerDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_sgsTurbDevice.cu \
+        ../HYDRO_CORE/CUDA/cuda_sgstkeDevice.cu \
+	../HYDRO_CORE/CUDA/cuda_canopyDevice.cu \
+        ../HYDRO_CORE/CUDA/cuda_largeScaleForcingsDevice.cu \
+        ../HYDRO_CORE/CUDA/cuda_moistureDevice.cu \
+        ../HYDRO_CORE/CUDA/cuda_filtersDevice.cu
+	rm -rf ./FastEddy_devlink.o; \
+	$(TEST_CU_CC) $(TEST_CU_CFLAGS) -fgpu-rdc -c $< -o $@
+################################################################################
+# Generic Executable
+# ###############################################################################
+
+FastEddy: COMP_FLAGS = ${TEST_CC} ${TEST_CFLAGS}
+
+TEST_DEPENDENCIES = ${TEST_OBJS} ${TEST_HDRS} FastEddy_devlink.o
+
+FastEddy_devlink.o:
+	$(TEST_CU_CC) ${ARCH_CU_FLAGS} ${TEST_OBJS} ${TEST_LDFLAGS} ${TEST_LIBS} -fgpu-rdc --hip-link --emit-static-lib -o FastEddy_devlink.o
+FastEddy: ${TEST_DEPENDENCIES}
+	${COMP_FLAGS} -o FastEddy ${TEST_OBJS} ./FastEddy_devlink.o ${TEST_LDFLAGS} ${TEST_LIBS}
+
+################################################################################
+# Clean
+# ################################################################################
+
+clean:
+	rm -rf ${TARGETS} ${TEST_OBJS} ${TEST_LIB_OBJS} ./FastEddy_devlink.o
+
+################################################################################
+# Check
+# ###############################################################################
+
+check:
+	@echo CC = ${CC}
+	@echo CFLAGS = ${CFLAGS} 
+	@echo LDFLAGS = ${LDFLAGS} 
+	@echo LIBS = ${LIBS}
+	@echo DEPENDENCIES = ${TEST_DEPENDENCIES}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ FastEddy should be cited as shown here:
 
    release_notes.rst
    run_ncar_hpcs.rst
+   run_amd_gpus.rst
    downloads.rst
    Tutorials/index
    publications.rst

--- a/docs/run_amd_gpus.rst
+++ b/docs/run_amd_gpus.rst
@@ -1,0 +1,40 @@
+.. _run_fasteddy_amdgpu:
+
+**************************
+Running under NSF NCAR HPC
+**************************
+
+These instructions will help users get started running FastEddy on systems with AMD GPUs.
+
+Prerequisites
+=============
+Before attempting to build FastEddy on a platform with AMD GPUs, verify that you have the following dependencies on your system
+
+* AMD Instinct GPU 
+* `ROCm 6.2 or later <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_
+* `GPU Aware MPI installation <https://rocm.blogs.amd.com/software-tools-optimization/gpu-aware-mpi/README.html>`_run_fasteddy
+* NetCDF-C library
+
+
+Compilation
+===========
+
+The Makefile-based build system included here assumes deployment on the NSF
+NCAR HPCs. FastEddy requires a C-compiler, MPI, and CUDA. Currently, the
+default modules loaded at login suffice on Casper, however the :code:`cuda` module
+will need to be loaded on Derecho by running :code:`module load cuda`.
+
+   1. Download the source code from the `Releases <https://github.com/NCAR/FastEddy-model/releases>`_ page and unpack the release in the desired location or clone the `repository <https://github.com/NCAR/FastEddy-model>`_ in the desired location.
+
+   2. Navigate to the **SRC/FEMAIN** directory.
+
+   3. To build the FastEddy executable run :code:`make -f Makefile.hip` (optionally run :code:`make clean` first if appropriate). Note that you may need to define the `OTHER_INCLUDES` environment variable to define the includes directories for NetCDF and OpenMPI, e.g. :code:`export OTHER_INCLUDES="-I${NETCDF_C_ROOT}/include -I${OPENMPI_ROOT}/include"`.
+
+The :code:`Makefile.hip` will convert all CUDA API calls and :code:`#include` headers to the appropriate HIP API calls and headers using the  :code:`hipify-perl -inplace` command.
+Following this, the code is compiled similarly to the CUDA version, but using the HIP compiler and libraries.
+
+The :code:`FastEddy` executable will be located in the **SRC/FEMAIN** directory. To
+build on other HPC systems with NVIDIA GPUs, check for availability of the aformentioned
+modules/dependencies. Successful compilation may require modifications to shell environment
+variable include or library paths, or alternatively minor adjustments to the include or library
+flags in **SRC/FEMAIN/Makefile**.


### PR DESCRIPTION
## Expected Differences ##

- [ ] Do these changes introduce new tools, command line arguments, or configuration file options? **[Yes or No]**</br>
If **yes**, please describe:</br>

Yes. This PR introduces `SRC/FEMAIN/Makefile.hip` which provides a build recipe for AMD GPUs. This makefile adds a build target called `hipify` that is used to run `hipify-perl -inplace` on all `.cu` and `.h` files under `SRC`. Translations were made for linker flags to be compatible with `hipcc`. Documentation has been added under `docs/run_amd_gpus.rst`

## Pull Request Testing ##

- [ ] Describe testing already performed for these changes:</br>
The code has been verified to compile on Ubuntu 22.04 system with 4x AMD MI210 GPUs and the following software environment
* gcc/12.3.0
* rocm/6.2.1
* openmpi/5.0.3 (+ROCm +UCX)
* netcdf-c/4.9.2

The convective boundary layer test case has also been run ( *STDOUT files will be posted shortly* ). The same model configuration has also been run on Ubuntu 22.04 system with 4x Nvidia V100 GPUs and the following software environment
* gcc/12.3.0
* cuda/12.0
* openmpi/5.0.3 (+CUDA)
* netcdf-c/4.9.2

**Relevant STDOUT**
[fasteddy.v100.stdout.txt](https://github.com/user-attachments/files/17878206/fasteddy.v100.stdout.txt)

Model state output files likely need to be compared - I could use some guidance here on how you'd want to do that.

Performance comparison still needs to be assessed.

Trace and hotspot profiles still need to be pulled for benchmark runs for comparative analysis between V100 and MI210.

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
I can provide SSH access for reviewers to our cluster with V100 and MI210 GPUs. This could help you build experience with running on both Nvidia and AMD platforms.

- [ ] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes or No]**
It would be good to develop the "how to run" with reviewers. Without a specific platform, we could write generic documentation for how to run FastEddy on AMD GPUs. However, build docs are provided.

- [ ] Do these changes include sufficient testing updates? **[Yes or No]**
For sufficient testing, CI ought to be configured to run regularly on AMD GPUs. [FluidNumerics/SuperCI](https://github.com/fluidnumerics/superci) is one option to do this on a system with a Slurm job scheduler, but a suitable AMD GPU platform ought to be identified for regular testing. 

- [ ] Will this PR result in changes to the test suite? **[Yes or No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
No. The same benchmarks should be run, just targeting AMD GPU platform in addition to the current platforms you test on.

- [ ] Please complete this pull request review by **12/31/2024**.</br>

## Pull Request Checklist ##
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Select: **Reviewer(s)**
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
